### PR TITLE
fixed the build on linux and added docker option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM toarnold/vbcc
+ENV VBCC /opt/vbccdev/
+RUN apk update
+RUN apk add python lha
+RUN wget www.haage-partner.de/download/AmigaOS/NDK39.lha -O - | lha x -w=/opt/vbccdev/ - 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,25 @@
-ifeq ($(OS),Linux)
-	DELCOM = rm -f
-else ifeq ($(OS),Windows_NT)
+
+ifeq ($(OS),Windows_NT)
 	DELCOM = del -f
-else ifeq ($(OS),Darwin)
-	DELCOM = rm -f
+else
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux) 
+DELCOM = rm -f
+else ifeq ($(UNAME_S),Darwin)
+DELCOM = rm -f
 else
 	DELCOM = DELETE FORCE
 endif
+endif
+
+VBCC?=/opt/vbcc/
+NDK=$(VBCC)/NDK_3.9
+NDK_INC=$(NDK)/Include/include_h
+CFLAGS?= -c99 -I$(NDK_INC)/libraries/ -I$(NDK_INC) -I.
 
 nvman: src/nvman.c src/commands.c src/commands.h src/utils.c src/utils.h
-	vc +aos68k src/nvman.c src/commands.c src/utils.c -o nvman
+	vc +aos68k $(CFLAGS) src/nvman.c src/commands.c src/utils.c -o nvman -lauto -lamiga 
 
 clean:
 	$(DELCOM) nvman


### PR DESCRIPTION
The OS env variable doesnt work on linux/macos. 
You need to specify include paths on linux.. added those
Added a dockerfile that you can build everything without needing a build environment.. 

docker build -t terriblefire/vbcc .

Then to build the sources

docker run --rm --volume "$PWD":/usr/src/compile --workdir /usr/src/compile -i -t terriblefire/vbcc make